### PR TITLE
Update Kuberhealthy apiVersion and image tag for v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: build push
 
 build: 
-	docker build -t rjacks161/ssh-check:v1.0.0 .
+	docker build -t rjacks161/ssh-check:v3.0.0 .
 
 push: 
-	docker push rjacks161/ssh-check:v1.0.0 
+	docker push rjacks161/ssh-check:v3.0.0 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This check requires two environment variables in the kube spec used to deploy it
 
 ```yaml
 ---
-apiVersion: comcast.github.io/v1
+apiVersion: kuberhealthy.github.io/v2
 kind: KuberhealthyCheck
 metadata:
   name: ssh-check
@@ -22,7 +22,7 @@ spec:
   podSpec:
     containers:
       - name: ssh-check
-        image: rjacks161/ssh-check:v1.0.0
+        image: rjacks161/ssh-check:v3.0.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SSH_PRIVATE_KEY

--- a/ssh-check.yaml
+++ b/ssh-check.yaml
@@ -1,4 +1,4 @@
-apiVersion: comcast.github.io/v1
+apiVersion: kuberhealthy.github.io/v2
 kind: KuberhealthyCheck
 metadata:
   name: ssh-check
@@ -13,7 +13,7 @@ spec:
   podSpec:
     containers:
       - name: ssh-check
-        image: rjacks161/ssh-check:v1.0.0
+        image: rjacks161/ssh-check:v3.0.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SSH_PRIVATE_KEY


### PR DESCRIPTION
## Summary
- use `kuberhealthy.github.io/v2` apiVersion in ssh check manifest and docs
- bump ssh check container image tag to v3.0.0
- refresh Makefile and README examples accordingly

## Testing
- `go test ./...` *(fails: command hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b92f6b7aa8832381d0fa93eebf8d17