### PR TITLE
chore: automate ghcr multi-arch releases

### DIFF
--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -28,20 +28,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Set image tag
         run: |
-          IMAGE_REPO="kuberhealthy/ssh-check"
+          IMAGE_REPO="ghcr.io/kuberhealthy/ssh-check"
           IMAGE_TAG="${IMAGE_REPO}:${GITHUB_REF_NAME}"
-          IMAGE_URL="https://hub.docker.com/r/${IMAGE_REPO}/tags?name=${GITHUB_REF_NAME}"
+          PACKAGE_URL="https://github.com/orgs/kuberhealthy/packages/container/package/ssh-check"
           echo "IMAGE_REPO=${IMAGE_REPO}" >> "$GITHUB_ENV"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
-          echo "IMAGE_URL=${IMAGE_URL}" >> "$GITHUB_ENV"
+          echo "PACKAGE_URL=${PACKAGE_URL}" >> "$GITHUB_ENV"
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -55,20 +56,20 @@ jobs:
       - name: Create release notes
         run: |
           cat > release-images.txt <<EOF
-          Image: docker.io/${IMAGE_TAG}
+          Image: ${IMAGE_TAG}
           Platforms: linux/amd64, linux/arm64
-          Docker Hub: ${IMAGE_URL}
+          GitHub Package: ${PACKAGE_URL}
           EOF
 
           cat > release-notes.md <<EOF
           Container images were published for this release.
 
-          - Image: `docker.io/${IMAGE_TAG}`
+          - Image: `${IMAGE_TAG}`
           - Platforms: `linux/amd64`, `linux/arm64`
-          - Docker Hub: ${IMAGE_URL}
+          - GitHub Package: ${PACKAGE_URL}
 
           ```sh
-          docker pull docker.io/${IMAGE_TAG}
+          docker pull ${IMAGE_TAG}
           ```
           EOF
 
@@ -87,6 +88,7 @@ jobs:
         run: |
           echo "Release created:" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${GITHUB_REF_NAME}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Images pushed:" >> "$GITHUB_STEP_SUMMARY"
+          echo "Image pushed:" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${IMAGE_TAG}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ${IMAGE_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Package:" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${PACKAGE_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -9,11 +9,18 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Validate release tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tags must use semver like v1.2.3 or v1.2.3-rc.1"
+            exit 1
+          fi
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -29,21 +36,57 @@ jobs:
 
       - name: Set image tag
         run: |
-          IMAGE_TAG="kuberhealthy/ssh-check:${GITHUB_REF_NAME}"
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          IMAGE_REPO="kuberhealthy/ssh-check"
+          IMAGE_TAG="${IMAGE_REPO}:${GITHUB_REF_NAME}"
+          IMAGE_URL="https://hub.docker.com/r/${IMAGE_REPO}/tags?name=${GITHUB_REF_NAME}"
+          echo "IMAGE_REPO=${IMAGE_REPO}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
+          echo "IMAGE_URL=${IMAGE_URL}" >> "$GITHUB_ENV"
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.IMAGE_TAG }}
+
+      - name: Create release notes
+        run: |
+          cat > release-images.txt <<EOF
+          Image: docker.io/${IMAGE_TAG}
+          Platforms: linux/amd64, linux/arm64
+          Docker Hub: ${IMAGE_URL}
+          EOF
+
+          cat > release-notes.md <<EOF
+          Container images were published for this release.
+
+          - Image: `docker.io/${IMAGE_TAG}`
+          - Platforms: `linux/amd64`, `linux/arm64`
+          - Docker Hub: ${IMAGE_URL}
+
+          ```sh
+          docker pull docker.io/${IMAGE_TAG}
+          ```
+          EOF
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+          else
+            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md --verify-tag
+          fi
+          gh release upload "${GITHUB_REF_NAME}" release-images.txt --clobber
+
       - name: Publish summary
         run: |
-          TAG="${IMAGE_TAG#*:}"
-          IMAGE_REPO="${IMAGE_TAG%:*}"
-          IMAGE_URL="https://hub.docker.com/r/${IMAGE_REPO}/tags?name=${TAG}"
+          echo "Release created:" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${GITHUB_REF_NAME}" >> "$GITHUB_STEP_SUMMARY"
           echo "Images pushed:" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${IMAGE_TAG}" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${IMAGE_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Checkout
+      - name: Checkout tag
         uses: actions/checkout@v4
 
       - name: Validate release tag
@@ -53,6 +53,37 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_TAG }}
 
+      - name: Update healthcheck examples
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch origin main
+          git checkout main
+          git pull --ff-only origin main
+
+          ruby <<'RUBY'
+          image_tag = ENV.fetch("IMAGE_TAG")
+          repo = "ssh-check"
+          files = Dir.glob("*.yaml") + Dir.glob("*.yml")
+          files.each do |path|
+            text = File.read(path)
+            updated = text.gsub(/(image: +)(?:S*/)?ssh\-check:[^ ]+/, "\1#{image_tag}")
+            next if updated == text
+            File.write(path, updated)
+          end
+          RUBY
+
+          if git diff --quiet; then
+            echo "No healthcheck image references needed updates."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add '*.yaml' '*.yml'
+          git commit -m "chore: update healthcheck image for ${GITHUB_REF_NAME}"
+          git push origin main
+
       - name: Create release notes
         run: |
           cat > release-images.txt <<EOF
@@ -67,6 +98,8 @@ jobs:
           - Image: `${IMAGE_TAG}`
           - Platforms: `linux/amd64`, `linux/arm64`
           - GitHub Package: ${PACKAGE_URL}
+
+          The example healthcheck manifest on `main` was updated to use this image tag.
 
           ```sh
           docker pull ${IMAGE_TAG}

--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -60,18 +60,7 @@ jobs:
           git fetch origin main
           git checkout main
           git pull --ff-only origin main
-
-          ruby <<'RUBY'
-          image_tag = ENV.fetch("IMAGE_TAG")
-          repo = "ssh-check"
-          files = Dir.glob("*.yaml") + Dir.glob("*.yml")
-          files.each do |path|
-            text = File.read(path)
-            updated = text.gsub(/(image: +)(?:S*/)?ssh\-check:[^ ]+/, "\1#{image_tag}")
-            next if updated == text
-            File.write(path, updated)
-          end
-          RUBY
+          ruby -e 'image_tag = ENV.fetch("IMAGE_TAG"); files = Dir.glob("*.yaml") + Dir.glob("*.yml"); files.each do |path| text = File.read(path); updated = text.gsub(/(image:\s+)(?:\S*\/)?ssh\-check:[^\s]+/) { "#{$1}#{image_tag}" }; File.write(path, updated) if updated != text; end'
 
           if git diff --quiet; then
             echo "No healthcheck image references needed updates."

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,21 +30,31 @@ jobs:
       - name: Set image tag
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          IMAGE_TAG="kuberhealthy/ssh-check:${SHORT_SHA}"
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          IMAGE_REPO="kuberhealthy/ssh-check"
+          IMAGE_TAG="${IMAGE_REPO}:${SHORT_SHA}"
+          LATEST_IMAGE_TAG="${IMAGE_REPO}:latest"
+          echo "IMAGE_REPO=${IMAGE_REPO}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
+          echo "LATEST_IMAGE_TAG=${LATEST_IMAGE_TAG}" >> "$GITHUB_ENV"
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.IMAGE_TAG }}
+          tags: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.LATEST_IMAGE_TAG }}
+
       - name: Publish summary
         run: |
           TAG="${IMAGE_TAG#*:}"
-          IMAGE_REPO="${IMAGE_TAG%:*}"
           IMAGE_URL="https://hub.docker.com/r/${IMAGE_REPO}/tags?name=${TAG}"
+          LATEST_IMAGE_URL="https://hub.docker.com/r/${IMAGE_REPO}/tags?name=latest"
           echo "Images pushed:" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${IMAGE_TAG}" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${IMAGE_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${LATEST_IMAGE_TAG}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${LATEST_IMAGE_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,21 +21,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Set image tag
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          IMAGE_REPO="kuberhealthy/ssh-check"
+          IMAGE_REPO="ghcr.io/kuberhealthy/ssh-check"
           IMAGE_TAG="${IMAGE_REPO}:${SHORT_SHA}"
           LATEST_IMAGE_TAG="${IMAGE_REPO}:latest"
+          PACKAGE_URL="https://github.com/orgs/kuberhealthy/packages/container/package/ssh-check"
           echo "IMAGE_REPO=${IMAGE_REPO}" >> "$GITHUB_ENV"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
           echo "LATEST_IMAGE_TAG=${LATEST_IMAGE_TAG}" >> "$GITHUB_ENV"
+          echo "PACKAGE_URL=${PACKAGE_URL}" >> "$GITHUB_ENV"
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -50,11 +53,8 @@ jobs:
 
       - name: Publish summary
         run: |
-          TAG="${IMAGE_TAG#*:}"
-          IMAGE_URL="https://hub.docker.com/r/${IMAGE_REPO}/tags?name=${TAG}"
-          LATEST_IMAGE_URL="https://hub.docker.com/r/${IMAGE_REPO}/tags?name=latest"
           echo "Images pushed:" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${IMAGE_TAG}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ${IMAGE_URL}" >> "$GITHUB_STEP_SUMMARY"
           echo "- ${LATEST_IMAGE_TAG}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ${LATEST_IMAGE_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Package:" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${PACKAGE_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-image-build.yaml
+++ b/.github/workflows/validate-image-build.yaml
@@ -1,0 +1,37 @@
+name: Validate image build
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - "go.mod"
+      - "go.sum"
+      - "cmd/**"
+      - ".github/workflows/validate-image-build.yaml"
+      - ".github/workflows/publish-tag.yaml"
+      - ".github/workflows/publish.yaml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /build
 COPY go.mod go.sum /build/
 
 COPY . /build
 WORKDIR /build/cmd/ssh-check
 ENV CGO_ENABLED=0
-RUN go build -v
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v
 
 FROM scratch
 COPY --from=builder /build/cmd/ssh-check/ssh-check /app/ssh-check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: build push
 
 build: 
-	docker build -t rjacks161/ssh-check:v3.0.0 .
+	docker build -t ghcr.io/kuberhealthy/ssh-check:v3.0.0 .
 
 push: 
-	docker push rjacks161/ssh-check:v3.0.0 
+	docker push ghcr.io/kuberhealthy/ssh-check:v3.0.0

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Check ssh connectivity to nodes within a cluster
 This repository builds the container image used by Kuberhealthy to run the ssh-check check.
 
 ## Image
-- `docker.io/kuberhealthy/ssh-check`
+- `ghcr.io/kuberhealthy/ssh-check`
 - Tags: short git SHA for `main` pushes and `vX.Y.Z` for releases.
 
 ## Quick start
-- Apply the example manifest: `kubectl apply -f ssh-check.yaml`
+- Apply the example manifest: `kubectl apply -f healthcheck.yaml`
 - Edit the manifest to set any required inputs for your environment.
 
 ## Build locally

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+# Release
+
+Releases are automated from semver git tags.
+
+To make a release, create and push a semver tag from the commit you want to release:
+
+```sh
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The `Publish tag` GitHub Actions workflow runs on `v*` tags and validates the tag format before publishing. Use `vMAJOR.MINOR.PATCH`, such as `v1.2.3`, or a prerelease tag like `v1.2.3-rc.1`.
+
+The workflow publishes this multi-arch image:
+
+```text
+docker.io/kuberhealthy/ssh-check:<tag>
+```
+
+The image manifest includes:
+
+- `linux/amd64`
+- `linux/arm64`
+
+After the image is pushed, the workflow creates or updates a GitHub release with the same semver as the tag. The release notes link to the Docker Hub image, and the release includes a `release-images.txt` asset listing the image and supported platforms.
+
+Docker image tags do not support `+`, so do not use semver build metadata in release tags.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,10 +11,10 @@ git push origin v1.2.3
 
 The `Publish tag` GitHub Actions workflow runs on `v*` tags and validates the tag format before publishing. Use `vMAJOR.MINOR.PATCH`, such as `v1.2.3`, or a prerelease tag like `v1.2.3-rc.1`.
 
-The workflow publishes this multi-arch image:
+The workflow publishes this multi-arch image to GitHub Container Registry:
 
 ```text
-docker.io/kuberhealthy/ssh-check:<tag>
+ghcr.io/kuberhealthy/ssh-check:<tag>
 ```
 
 The image manifest includes:
@@ -22,6 +22,6 @@ The image manifest includes:
 - `linux/amd64`
 - `linux/arm64`
 
-After the image is pushed, the workflow creates or updates a GitHub release with the same semver as the tag. The release notes link to the Docker Hub image, and the release includes a `release-images.txt` asset listing the image and supported platforms.
+After the image is pushed, the workflow creates or updates a GitHub release with the same semver as the tag. The release notes link to the GitHub package, and the release includes a `release-images.txt` asset listing the image and supported platforms.
 
 Docker image tags do not support `+`, so do not use semver build metadata in release tags.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,8 @@ The image manifest includes:
 - `linux/amd64`
 - `linux/arm64`
 
-After the image is pushed, the workflow creates or updates a GitHub release with the same semver as the tag. The release notes link to the GitHub package, and the release includes a `release-images.txt` asset listing the image and supported platforms.
+After the image is pushed, the workflow updates the example healthcheck YAML on `main` to use the released GHCR image tag.
+
+The workflow then creates or updates a GitHub release with the same semver as the tag. The release notes link to the GitHub package, and the release includes a `release-images.txt` asset listing the image and supported platforms.
 
 Docker image tags do not support `+`, so do not use semver build metadata in release tags.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ssh-check
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/kuberhealthy/kuberhealthy/v3 v3.0.0-20250904060524-9ccb8db8e238

--- a/healthcheck.yaml
+++ b/healthcheck.yaml
@@ -13,7 +13,7 @@ spec:
   podSpec:
     containers:
       - name: ssh-check
-        image: rjacks161/ssh-check:v1.1.0
+        image: ghcr.io/kuberhealthy/ssh-check:sha-<short-sha>
         imagePullPolicy: IfNotPresent
         env:
           - name: SSH_PRIVATE_KEY


### PR DESCRIPTION
Automates semver-tagged multi-arch releases for this check using GitHub Container Registry.

Parent issue: https://github.com/kuberhealthy/kuberhealthy/issues/1502

Changes:
- Publish linux/amd64 and linux/arm64 images from GitHub Actions.
- Host images in GHCR as ghcr.io/kuberhealthy/<check>:<tag>.
- Update example healthcheck YAML on main to the released GHCR image tag.
- Create or update a GitHub release when a semver tag is pushed.
- Attach release-images.txt and link the GHCR package in the release notes.
- Document the release process in RELEASE.md.

Validation:
- GitHub Actions validates multi-arch image builds on pull requests.
- Ruby YAML parse for all workflows.
- bash -n for all workflow run blocks.- git diff --check